### PR TITLE
Fix typos and build config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export interface CliOptions {
   projectName: string
   templateName: string
   templatePath: string
-  tartgetPath: string
+  targetPath: string
   config: TemplateConfig
 }
 
@@ -53,18 +53,18 @@ inquirer.prompt(QUESTIONS)
     const projectChoice = answers['template'];
     const projectName = answers['name'];
     const templatePath = path.join(__dirname, 'templates', projectChoice);
-    const tartgetPath = path.join(CURR_DIR, projectName);
+    const targetPath = path.join(CURR_DIR, projectName);
     const templateConfig = getTemplateConfig(templatePath);
 
     const options: CliOptions = {
       projectName,
       templateName: projectChoice,
       templatePath,
-      tartgetPath,
+      targetPath,
       config: templateConfig
     }
 
-    if (!createProject(tartgetPath)) {
+    if (!createProject(targetPath)) {
       return;
     }
 
@@ -128,7 +128,7 @@ function isNode(options: CliOptions) {
 }
 
 function postProcessNode(options: CliOptions) {
-  shell.cd(options.tartgetPath);
+  shell.cd(options.targetPath);
 
   let cmd = '';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
       "noImplicitThis": true,
       "noImplicitAny": true,
       "strictNullChecks": true,
-      "suppressImplicitAnyIndexErrors": true,
       "noUnusedLocals": true
     },
     "exclude": [


### PR DESCRIPTION
## Summary
- correct typo `tartgetPath` -> `targetPath`
- remove deprecated option from tsconfig

## Testing
- `npm run build` *(fails: Cannot find module 'inquirer')*
- `npx tsc` *(fails: Cannot find module 'inquirer')*